### PR TITLE
Allowed to specify ref argument to git/github projects.

### DIFF
--- a/bin/licensee
+++ b/bin/licensee
@@ -9,6 +9,7 @@ require_relative '../lib/licensee'
 class LicenseeCLI < Thor
   package_name 'Licensee'
   class_option :remote, type: :boolean, desc: 'Assume PATH is a GitHub owner/repo path'
+  class_option :ref, type: :string, desc: 'Optional ref specifies the desired git revision'
   default_task :detect
 
   private
@@ -23,7 +24,8 @@ class LicenseeCLI < Thor
 
   def project
     @project ||= Licensee.project(path,
-                                  detect_packages: options[:packages], detect_readme: options[:readme])
+                                  detect_packages: options[:packages], detect_readme: options[:readme],
+                                  revision: options[:ref])
   end
 
   def remote?

--- a/lib/licensee/projects/fs_project.rb
+++ b/lib/licensee/projects/fs_project.rb
@@ -8,7 +8,8 @@
 module Licensee
   module Projects
     class FSProject < Licensee::Projects::Project
-      def initialize(path, **args)
+      def initialize(path, revision: nil, **args)
+        # revision isn't used by fs_project
         if ::File.file?(path)
           @pattern = File.basename(path)
           @dir = File.expand_path File.dirname(path)

--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -36,7 +36,11 @@ module Licensee
 
       def commit
         @commit ||= if revision
-          repository.lookup(revision)
+          commit = repository.rev_parse(revision)
+          while !commit.is_a?(Rugged::Commit) do
+            commit = commit.target
+          end
+          commit
         else
           repository.last_commit
         end

--- a/lib/licensee/projects/github_project.rb
+++ b/lib/licensee/projects/github_project.rb
@@ -17,9 +17,10 @@ module Licensee
 
       class RepoNotFound < StandardError; end
 
-      def initialize(github_url, **args)
+      def initialize(github_url, revision: nil, **args)
         @repo = github_url[GITHUB_REPO_PATTERN, 1]
         raise ArgumentError, "Not a github URL: #{github_url}" unless @repo
+        @revision = revision
 
         super(**args)
       end
@@ -40,7 +41,8 @@ module Licensee
 
       def load_file(file)
         client.contents(@repo, path:   file[:path],
-                               accept: 'application/vnd.github.v3.raw').to_s
+                               accept: 'application/vnd.github.v3.raw',
+                               ref:    @revision).to_s
       end
 
       def dir_files(path = nil)


### PR DESCRIPTION
This is a review for a change that will be submitted upstream.

Licensee is a ruby gem and command line tool for searching a software library for its license text and checking that text for conformity with a known license type. This gives us a more reliable automated license report than reading from the package.json.

I haven't yet provided tests. Might need help there. I'm new to Ruby.