### PR TITLE
Attribution plus

### DIFF
--- a/lib/licensee/project_files/project_file.rb
+++ b/lib/licensee/project_files/project_file.rb
@@ -12,7 +12,8 @@ module Licensee
 
       include Licensee::HashHelper
       HASH_METHODS = %i[
-        filename content content_hash content_normalized matcher matched_license attribution
+        filename content content_hash content_normalized matcher matched_license
+        attribution
       ].freeze
 
       ENCODING = Encoding::UTF_8

--- a/lib/licensee/project_files/project_file.rb
+++ b/lib/licensee/project_files/project_file.rb
@@ -12,7 +12,7 @@ module Licensee
 
       include Licensee::HashHelper
       HASH_METHODS = %i[
-        filename content content_hash content_normalized matcher matched_license
+        filename content content_hash content_normalized matcher matched_license attribution
       ].freeze
 
       ENCODING = Encoding::UTF_8
@@ -97,6 +97,10 @@ module Licensee
       end
 
       def content_normalized
+        nil
+      end
+
+      def attribution
         nil
       end
     end

--- a/spec/fixtures/detect.json
+++ b/spec/fixtures/detect.json
@@ -86,6 +86,7 @@
   ],
   "matched_files": [
     {
+      "attribution": "Copyright (c) 2014-2017 Ben Balter",
       "filename": "LICENSE.md",
       "content": "MIT License\n\nCopyright (c) 2014-2017 Ben Balter\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n",
       "content_hash": "d64f3bb4282a97b37454b5bb96a8a264a3363dc3",
@@ -97,6 +98,7 @@
       "matched_license": "MIT"
     },
     {
+      "attribution": null,
       "filename": "licensee.gemspec",
       "content": "require File.expand_path('lib/licensee/version', __dir__)\n\nGem::Specification.new do |gem|\n  gem.name    = 'licensee'\n  gem.version = Licensee::VERSION\n\n  gem.summary = 'A Ruby Gem to detect open source project licenses'\n  gem.description = <<-DESC\n    Licensee automates the process of reading LICENSE files and\n    compares their contents to known licenses using a fancy maths.\n  DESC\n\n  gem.authors  = ['Ben Balter']\n  gem.email    = 'ben.balter@github.com'\n  gem.homepage = 'https://github.com/benbalter/licensee'\n  gem.license  = 'MIT'\n\n  gem.bindir = 'bin'\n  gem.executables << 'licensee'\n\n  gem.add_dependency('dotenv', '~> 2.0')\n  gem.add_dependency('octokit', '~> 4.8.0')\n  gem.add_dependency('reverse_markdown', '~> 1.0')\n  gem.add_dependency('rugged', '~> 0.24')\n  gem.add_dependency('thor', '~> 0.19')\n\n  gem.add_development_dependency('mustache', '>= 0.9', '< 2.0')\n  gem.add_development_dependency('pry', '~> 0.9')\n  gem.add_development_dependency('rake', '~> 10.3')\n  gem.add_development_dependency('rspec', '~> 3.5')\n  gem.add_development_dependency('rubocop', '~> 0.49')\n  gem.add_development_dependency('simplecov', '~> 0.16')\n  gem.add_development_dependency('webmock', '~> 3.1')\n\n  gem.required_ruby_version = '> 2.2'\n\n  # ensure the gem is built out of versioned files\n  gem.files = Dir[\n    'Rakefile',\n    '{bin,lib,man,test,vendor,spec}/**/*',\n    'README*', 'LICENSE*'\n  ] & `git ls-files -z`.split(\"\\0\")\nend\n",
       "content_hash": null,

--- a/spec/licensee/project_files/project_file_spec.rb
+++ b/spec/licensee/project_files/project_file_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Licensee::ProjectFiles::ProjectFile do
     let(:hash) { subject.to_h }
     let(:expected) do
       {
+        attribution:        'Copyright (c) [year] [fullname]',
         filename:           'LICENSE.txt',
         content:            mit.content.to_s,
         content_hash:       subject.content_hash,


### PR DESCRIPTION
Exposes the attribution field in the matched files json array, and allows multiline attributions which exist in some license files.